### PR TITLE
Include methods as composer suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,10 @@
         "phpunit/phpunit": "^5.7",
         "squizlabs/php_codesniffer": "^3.0"
     },
+    "suggest": {
+    "silverstripe/totp-authenticator": "Adds a method to authenticate with you phone using a time-based one-time password.",
+    "silverstripe/webauthn-authenticator": "Adds a method to authenticate with security keys or built-in platform authenticators.",
+    },
     "extra": {
         "expose": [
             "client/dist"


### PR DESCRIPTION
Adding the two authenticating methods as suggestions in the composer.json file, seeing as we won’t be making a installable recipe